### PR TITLE
Support for describing layouts for a specific sobject

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ client.describe('Account')
 # => { ... }
 ```
 
+### describe_layouts
+
+```ruby
+# get layouts for an sobject type
+client.describe_layout('Account')
+# => { ... }
+
+# get the details for a specific layout
+client.describe_layouts('Account', '012E0000000RHEp')
+# => { ... }
+```
+
 ### picklist\_values
 
 

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -65,6 +65,30 @@ module Restforce
         end
       end
 
+      # Public: Returns a detailed description of the Page Layout for the
+      # specified sobject type, or URIs for layouts if the sobject has
+      # multiple Record Types.
+      #
+      # This resource was introduced in version 28.0.
+      #
+      # Examples:
+      #  # get the layouts for the sobject
+      #  client.describe_layouts('Account')
+      #  # => { ... }
+      #
+      #  # get the layout for the specified Id for the sobject
+      #  client.describe_layouts('Account', '012E0000000RHEp')
+      #  # => { ... }
+      #
+      # Returns the Hash representation of the describe_layouts result
+      def describe_layouts(sobject, layout_id = nil)
+        if layout_id
+          api_get("sobjects/#{sobject.to_s}/describe/layouts/#{layout_id}").body
+        else
+          api_get("sobjects/#{sobject.to_s}/describe/layouts").body
+        end
+      end
+
       # Public: Get the current organization's Id.
       #
       # Examples

--- a/lib/restforce/sobject.rb
+++ b/lib/restforce/sobject.rb
@@ -10,6 +10,11 @@ module Restforce
       @client.describe(sobject_type)
     end
 
+    # Public: Describe layouts for this sobject type
+    def describe_layouts(layout_id = nil)
+      @client.describe_layouts(sobject_type, layout_id)
+    end
+
     # Public: Persist the attributes to Salesforce.
     #
     # Examples

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -37,6 +37,28 @@ describe Restforce::Concerns::API do
     end
   end
 
+  describe '.describe_layouts' do
+    subject(:describe_layouts) { client.describe_layouts('Whizbang') }
+
+    it 'returns the layouts for the sobject' do
+      client.should_receive(:api_get).
+        with('sobjects/Whizbang/describe/layouts').
+        and_return(response)
+      expect(describe_layouts).to eq response.body
+    end
+
+    context 'when given the id of a layout' do
+      subject(:describe_layouts) { client.describe_layouts('Whizbang', '012E0000000RHEp') }
+
+      it 'returns the describe for the specified layout' do
+        client.should_receive(:api_get).
+          with('sobjects/Whizbang/describe/layouts/012E0000000RHEp').
+          and_return(response)
+        expect(describe_layouts).to eq response.body
+      end
+    end
+  end
+
   describe '.org_id' do
     subject(:org_id) { client.org_id }
 

--- a/spec/unit/sobject_spec.rb
+++ b/spec/unit/sobject_spec.rb
@@ -65,4 +65,22 @@ describe Restforce::SObject do
 
     it { should_not raise_error }
   end
+
+  describe '.describe_layouts' do
+    let(:layout_id) { nil }
+    subject { lambda { sobject.describe_layouts } }
+
+    before do
+      client.should_receive(:describe_layouts).with('Whizbang', layout_id)
+    end
+
+    it { should_not raise_error }
+
+    context 'when a layout Id is specified' do
+      let(:layout_id) { '012E0000000RHEp' }
+      subject { lambda { sobject.describe_layouts(layout_id) } }
+
+      it { should_not raise_error }
+    end
+  end
 end


### PR DESCRIPTION
This change adds support for functionality introduced in v28.0 of the REST API to describe Page Layouts.
