### PR TITLE
Add a :mashify option to turn off the Mashify middleware

### DIFF
--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -34,6 +34,8 @@ module Restforce
       #                                  before raising an exception (default: 3).
       #
       #        :compress               - Set to true to have Salesforce compress the response (default: false).
+      #        :mashify                - Set to false to skip the conversion of Salesforce responses to
+      #                                  Restforce::Sobjects and Restforce::Collections. (default: nil).
       #        :timeout                - Faraday connection request read/open timeout. (default: nil).
       #
       #        :proxy_uri              - Proxy URI: 'http://proxy.example.com:port' or 'http://user@pass:proxy.example.com:port'

--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -22,7 +22,7 @@ module Restforce
       def connection
         @connection ||= Faraday.new(options[:instance_url], connection_options) do |builder|
           # Parses JSON into Hashie::Mash structures.
-          builder.use      Restforce::Middleware::Mashify, self, options
+          builder.use      Restforce::Middleware::Mashify, self, options unless (options[:mashify] == false)
           # Handles multipart file uploads for blobs.
           builder.use      Restforce::Middleware::Multipart
           # Converts the request into JSON.

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -117,6 +117,10 @@ module Restforce
     # Set to true if you want responses from Salesforce to be gzip compressed.
     option :compress
 
+    # Set to false if you want to skip conversion to Restforce::Sobjects and
+    # Restforce::Collections.
+    option :mashify
+
     # Faraday request read/open timeout.
     option :timeout
 

--- a/spec/support/client_integration.rb
+++ b/spec/support/client_integration.rb
@@ -39,7 +39,7 @@ module ClientIntegrationExampleGroup
       }
 
     config.before :mashify => false do
-      client.middleware.delete(Restforce::Middleware::Mashify)
+      base_options.merge!(:mashify => false)
     end
   end
 end

--- a/spec/unit/concerns/connection_spec.rb
+++ b/spec/unit/concerns/connection_spec.rb
@@ -11,4 +11,46 @@ describe Restforce::Concerns::Connection do
 
     it { should eq builder }
   end
+
+  describe 'private #connection' do
+    describe ':mashify option' do
+      before(:each) do
+        client.stub(:authentication_middleware)
+        client.stub(:cache)
+      end
+
+      describe 'with mashify not specified' do
+        before(:each) do
+          client.stub(:options).and_return({})
+        end
+
+        it 'includes the Mashify middleware' do
+          client.middleware.handlers.index(Restforce::Middleware::Mashify).
+              should_not be_nil
+        end
+      end
+
+      describe 'with mashify=true' do
+        before(:each) do
+          client.stub(:options).and_return(:mashify => true)
+        end
+
+        it 'includes the Mashify middleware' do
+          client.middleware.handlers.index(Restforce::Middleware::Mashify).
+              should_not be_nil
+        end
+      end
+
+      describe 'without mashify' do
+        before(:each) do
+          client.stub(:options).and_return(:mashify => false)
+        end
+
+        it 'does not include the Mashify middleware' do
+          client.middleware.handlers.index(Restforce::Middleware::Mashify).
+              should be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,7 @@ describe Restforce do
       its(:adapter)                { should eq Faraday.default_adapter }
       [:username, :password, :security_token, :client_id, :client_secret,
        :oauth_token, :refresh_token, :instance_url, :compress, :timeout,
-       :proxy_uri, :authentication_callback].each do |attr|
+       :proxy_uri, :authentication_callback, :mashify].each do |attr|
         its(attr) { should be_nil }
       end
     end
@@ -55,7 +55,7 @@ describe Restforce do
   describe '#configure' do
     [:username, :password, :security_token, :client_id, :client_secret, :compress, :timeout,
      :oauth_token, :refresh_token, :instance_url, :api_version, :host, :authentication_retries,
-     :proxy_uri, :authentication_callback].each do |attr|
+     :proxy_uri, :authentication_callback, :mashify].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
           config.send("#{attr}=", 'foobar')


### PR DESCRIPTION
This option makes it possible to get raw responses without directly
modifying the middleware stack.

The Mashify middleware is not inserted if the :mashify option == false.
The default is nil to retain back compatibility.

The Restforce::Concerns::Connection#mashify? method is unmodified. It still
looks at the middleware stack to determine if it includes Mashify, so there
should be no change in behavior for existing uses that modify the
stack directly to remove Mashify.
