### PR TITLE
GROW-967: Loosen dependency version restrictions to support `omniauth` upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2 (Mar 11, 2022)
+
+* Loosened some dependency version restrictions
+
 ## 1.4.1 (Jun 18, 2013)
 
 *   Fixed a bug with HTTP 413 responses #75 @patronmanager

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,3 +1,3 @@
 module Restforce
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Restforce::VERSION
 
-  gem.add_dependency 'faraday', '~> 0.8.4'
+  gem.add_dependency 'faraday', '~> 0.17'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
   gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
-  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.1']
+  gem.add_dependency 'hashie', '>= 1.2.0'
 
   gem.add_development_dependency 'rspec', '~> 2.14.0'
   gem.add_development_dependency 'webmock', '~> 1.13.0'


### PR DESCRIPTION
This gem is used by `yeti_crm_models`, which is in turn used in `Backend`. There are dependency conflicts that must be relieved here to allow us to upgrade `omniauth` to 2.0.